### PR TITLE
[MC 1.20.1] Revert restricted forge version to unblock compatibility with NeoForge (issue #45)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,6 @@ java {
     withSourcesJar()
 }
 
-// NOTE: its not ported to neoforge yet, but its cross compatible now
-version = "neoforge-${mc_version}-${mod_version}"
-
 group = project.group
 description = project.displayname
 base.archivesName = project.name

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,14 @@ plugins {
     id 'idea'
     id 'maven-publish'
     id 'dev.architectury.loom' version '1.4.+'
+    id 'org.ajoberstar.reckon' version '0.13.0'
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
+    withSourcesJar()
 }
 
 // NOTE: its not ported to neoforge yet, but its cross compatible now
@@ -16,9 +18,7 @@ version = "neoforge-${mc_version}-${mod_version}"
 
 group = project.group
 description = project.displayname
-base {
-    archivesName = "PresenceFootsteps"
-}
+base.archivesName = project.name
 
 loom {
     mixin.defaultRefmapName = 'presencefootsteps.mixin.refmap.json'
@@ -30,8 +30,14 @@ loom {
     silentMojangMappingsLicense()
 }
 
-repositories {
+reckon {
+    scopeFromProp()
+    stageFromProp('beta', 'rc', 'final')
+}
 
+repositories {
+    maven { name 'minelp'; url 'https://repo.minelittlepony-mod.com/maven/snapshot' }
+    maven { name 'minelp-release'; url 'https://repo.minelittlepony-mod.com/maven/release' }
 }
 
 dependencies {
@@ -39,19 +45,6 @@ dependencies {
     mappings loom.officialMojangMappings()
 
     forge "net.minecraftforge:forge:${mc_version}-${forge_version}"
-}
-
-publishing {
-    publications {
-        register('mavenJava', MavenPublication) {
-            artifact jar
-        }
-    }
-    repositories {
-        maven {
-            url "file://${project.projectDir}/mcmodsrepo"
-        }
-    }
 }
 
 tasks.named('processResources', ProcessResources) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,24 @@
 plugins {
     id 'java-library'
+    id 'idea'
+    id 'maven-publish'
     id 'dev.architectury.loom' version '1.4.+'
-  //  id 'org.ajoberstar.reckon' version '0.13.0'
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
-    withSourcesJar()
 }
+
+// NOTE: its not ported to neoforge yet, but its cross compatible now
+version = "neoforge-${mc_version}-${mod_version}"
 
 group = project.group
 description = project.displayname
-base.archivesName = project.name
+base {
+    archivesName = "PresenceFootsteps"
+}
 
 loom {
     mixin.defaultRefmapName = 'presencefootsteps.mixin.refmap.json'
@@ -24,22 +29,29 @@ loom {
 
     silentMojangMappingsLicense()
 }
-/*
-reckon {
-    scopeFromProp()
-    stageFromProp('beta', 'rc', 'final')
-}*/
 
 repositories {
-    maven { name 'minelp'; url 'https://repo.minelittlepony-mod.com/maven/snapshot' }
-    maven { name 'minelp-release'; url 'https://repo.minelittlepony-mod.com/maven/release' }
+
 }
 
 dependencies {
-    minecraft "com.mojang:minecraft:1.20.1"
+    minecraft "com.mojang:minecraft:${mc_version}"
     mappings loom.officialMojangMappings()
 
-    forge "net.minecraftforge:forge:1.20.1-47.1.47"
+    forge "net.minecraftforge:forge:${mc_version}-${forge_version}"
+}
+
+publishing {
+    publications {
+        register('mavenJava', MavenPublication) {
+            artifact jar
+        }
+    }
+    repositories {
+        maven {
+            url "file://${project.projectDir}/mcmodsrepo"
+        }
+    }
 }
 
 tasks.named('processResources', ProcessResources) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-library'
     id 'dev.architectury.loom' version '1.4.+'
-    id 'org.ajoberstar.reckon' version '0.13.0'
+  //  id 'org.ajoberstar.reckon' version '0.13.0'
 }
 
 java {
@@ -24,11 +24,11 @@ loom {
 
     silentMojangMappingsLicense()
 }
-
+/*
 reckon {
     scopeFromProp()
     stageFromProp('beta', 'rc', 'final')
-}
+}*/
 
 repositories {
     maven { name 'minelp'; url 'https://repo.minelittlepony-mod.com/maven/snapshot' }
@@ -39,7 +39,7 @@ dependencies {
     minecraft "com.mojang:minecraft:1.20.1"
     mappings loom.officialMojangMappings()
 
-    forge "net.minecraftforge:forge:1.20.1-47.2.19"
+    forge "net.minecraftforge:forge:1.20.1-47.1.47"
 }
 
 tasks.named('processResources', ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.daemon=false
 loom.platform=forge
 
 mc_version=1.20.1
-mod_version=1.9.1
 forge_version=47.1.47
+
 # Mod Properties
   group=com.presencefootsteps
   displayname=Presence Footsteps

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@ org.gradle.daemon=false
 
 loom.platform=forge
 
+mc_version=1.20.1
+mod_version=1.9.1
+forge_version=47.1.47
 # Mod Properties
   group=com.presencefootsteps
   displayname=Presence Footsteps

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,4 +16,3 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
-rootProject.name = 'PresenceFootsteps'

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,3 +16,4 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+rootProject.name = 'PresenceFootsteps'

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ issueTrackerURL = "https://github.com/PaintNinja/Presence-Footsteps-Forge"
 
 [[mods]]
 modId = "presencefootsteps"
-version = "1.20.1-1.9.1-beta.1"
+version = "1.20.1-1.9.1"
 displayName = "Presence Footsteps (Forge)"
 displayURL = "https://www.curseforge.com/minecraft/mc-mods/presence-footsteps-forge"
 updateJSONURL = "https://forge.curseupdate.com/433068/presencefootsteps"
@@ -17,6 +17,7 @@ displayTest="IGNORE_ALL_VERSION"
 [[dependencies.presencefootsteps]]
 modId = "forge"
 mandatory = true
+# if you lock into 47.2.* then neoforge will not load
 versionRange = "[47.1.47,)"
 ordering = "NONE"
 side = "CLIENT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ issueTrackerURL = "https://github.com/PaintNinja/Presence-Footsteps-Forge"
 
 [[mods]]
 modId = "presencefootsteps"
-version = "1.20.1-1.9.1"
+version = "1.20.1-1.9.1-beta.1"
 displayName = "Presence Footsteps (Forge)"
 displayURL = "https://www.curseforge.com/minecraft/mc-mods/presence-footsteps-forge"
 updateJSONURL = "https://forge.curseupdate.com/433068/presencefootsteps"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -17,7 +17,7 @@ displayTest="IGNORE_ALL_VERSION"
 [[dependencies.presencefootsteps]]
 modId = "forge"
 mandatory = true
-versionRange = "[47.2.19,)"
+versionRange = "[47.1.47,)"
 ordering = "NONE"
 side = "CLIENT"
 


### PR DESCRIPTION
The internal code of the mod is already compatible between forge and neoforge.. at least in MC1.20.1 specifically, not sure about new mc versions.


Therefore, if we undo the restriction in the META mods toml file and a few other tweaks it runs fine in neoforge.

(the other commits in the branch are me making a local build and then reverting some changes. and setting the version in properties file)